### PR TITLE
Update @types/node to v16

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,7 +9,7 @@
     },
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "12.x"
+      "allowedVersions": "16.x"
     },
     {
       "matchPackageNames": ["jest", "ts-jest"],


### PR DESCRIPTION
https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/