### PR TITLE
Set `using` version to semver-coerced

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,6 +32,7 @@
         "^.+/action.ya?ml$"
       ],
       "matchStrings": ["using: 'node(?<currentValue>\\d+)'"],
+      "versioningTemplate": "semver-coerced",
       "depNameTemplate": "@types/node",
       "datasourceTemplate": "npm"
     }


### PR DESCRIPTION
https://app.renovatebot.com/dashboard#github/int128/deploy-lambda-action/1026653848

```
DEBUG: Found match at index 674(packageFile="action.yaml", branch="renovate/pin-dependencies")
{
  "depName": "@types/node"
}
DEBUG: Could not extract action.yaml(branch="renovate/pin-dependencies")
WARN: Error updating branch: update failure(branch="renovate/pin-dependencies")
```
