### PR TITLE
Replace matchPaths with matchFileNames

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,7 +27,7 @@
     {
       "description": "Disable pinning of node version",
       "matchPackageNames": ["node"],
-      "matchPaths": ["**/action.yaml", "**/action.yml", "package.json"],
+      "matchFileNames": ["**/action.yaml", "**/action.yml", "package.json"],
       "rangeStrategy": "auto"
     }
   ],


### PR DESCRIPTION
> https://docs.renovatebot.com/release-notes-for-major-versions/
> matchPaths and matchFiles are now combined into matchFileNames, supporting exact match and glob-only. The "any string match" functionality of matchPaths is now removed
