### PR TITLE
Support node20 runtime

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,16 +19,11 @@
       "automerge": true
     },
     {
-      "description": "Restrict the version supported in GitHub Actions",
+      "description": "Update Node version of this action",
       "matchPackageNames": ["node", "@types/node"],
       "groupName": "node",
-      "allowedVersions": "16.x"
-    },
-    {
-      "description": "Disable pinning of node version",
-      "matchPackageNames": ["node"],
-      "matchFileNames": ["**/action.yaml", "**/action.yml", "package.json"],
-      "rangeStrategy": "auto"
+      "versioning": "npm",
+      "allowedVersions": "20.x"
     }
   ],
   "regexManagers": [
@@ -39,6 +34,13 @@
         "^.+/action.ya?ml$"
       ],
       "matchStrings": ["using: 'node(?<currentValue>\\d+)'"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "npm"
+    },
+    {
+      "description": "Update node-version in workflows",
+      "fileMatch": ["^\\.github/workflows/.+\\.ya?ml$"],
+      "matchStrings": ["node-version: +(?<currentValue>\\d+)\\n"],
       "depNameTemplate": "node",
       "datasourceTemplate": "npm"
     },


### PR DESCRIPTION
This adds a support to update an action to `node20` runtime.

It will updates:
- `using` field in action.yaml
- `node-version` field in a worfklow
- `engines` field in package.json
- `@types/node` version

Tested as https://github.com/int128/typescript-action-sandbox-renovate/pull/1
